### PR TITLE
Add output format options to namespace list

### DIFF
--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -16,6 +16,7 @@ package namespace
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -30,7 +31,7 @@ import (
 )
 
 var (
-	errInvalidOutput = fmt.Errorf("output format is not accepted. Value must be one of: ['json', 'yaml']")
+	errInvalidOutput = errors.New("output format is not accepted. Value must be one of: ['json', 'yaml']")
 )
 
 type listFlags struct {

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -40,6 +40,7 @@ type listFlags struct {
 type namespaceOutput struct {
 	Namespace string `json:"namespace" yaml:"namespace"`
 	Status    string `json:"status" yaml:"status"`
+	Current   bool   `json:"current" yaml:"current"`
 }
 
 // List all namespace in current context
@@ -136,10 +137,12 @@ func validateNamespaceListOutput(output string) error {
 // getNamespaceOutput transforms type.Namespace into namespaceOutput type
 func getNamespaceOutput(namespaces []types.Namespace) []namespaceOutput {
 	var namespaceSlice []namespaceOutput
+	currentNamespace := okteto.GetContext().Namespace
 	for _, ns := range namespaces {
 		previewOutput := namespaceOutput{
 			Namespace: ns.ID,
 			Status:    ns.Status,
+			Current:   ns.ID == currentNamespace,
 		}
 		namespaceSlice = append(namespaceSlice, previewOutput)
 	}

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -29,7 +29,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// List all namespace in current context
 var (
 	errInvalidOutput = fmt.Errorf("output format is not accepted. Value must be one of: ['json', 'yaml']")
 )
@@ -43,6 +42,7 @@ type namespaceOutput struct {
 	Status    string `json:"status" yaml:"status"`
 }
 
+// List all namespace in current context
 func List(ctx context.Context) *cobra.Command {
 	flags := &listFlags{}
 	cmd := &cobra.Command{

--- a/cmd/namespace/list_test.go
+++ b/cmd/namespace/list_test.go
@@ -136,8 +136,8 @@ func Test_displayListNamespaces(t *testing.T) {
 			name:   "default format",
 			format: "",
 			input: []namespaceOutput{
-				{Namespace: "test", Status: "Active"},
-				{Namespace: "test2", Status: "Sleeping"},
+				{Namespace: "test", Status: "Active", Current: true},
+				{Namespace: "test2", Status: "Sleeping", Current: false},
 			},
 			expectedOutput: "Namespace  Status\ntest *     Active\ntest2      Sleeping\n",
 		},
@@ -145,19 +145,19 @@ func Test_displayListNamespaces(t *testing.T) {
 			name:   "json format",
 			format: "json",
 			input: []namespaceOutput{
-				{Namespace: "test", Status: "Active"},
-				{Namespace: "test2", Status: "Sleeping"},
+				{Namespace: "test", Status: "Active", Current: true},
+				{Namespace: "test2", Status: "Sleeping", Current: false},
 			},
-			expectedOutput: "[\n {\n  \"namespace\": \"test\",\n  \"status\": \"Active\"\n },\n {\n  \"namespace\": \"test2\",\n  \"status\": \"Sleeping\"\n }\n]\n",
+			expectedOutput: "[\n {\n  \"namespace\": \"test\",\n  \"status\": \"Active\",\n  \"current\": true\n },\n {\n  \"namespace\": \"test2\",\n  \"status\": \"Sleeping\",\n  \"current\": false\n }\n]\n",
 		},
 		{
 			name:   "yaml format",
 			format: "yaml",
 			input: []namespaceOutput{
-				{Namespace: "test", Status: "Active"},
-				{Namespace: "test2", Status: "Sleeping"},
+				{Namespace: "test", Status: "Active", Current: true},
+				{Namespace: "test2", Status: "Sleeping", Current: false},
 			},
-			expectedOutput: "- namespace: test\n  status: Active\n- namespace: test2\n  status: Sleeping\n",
+			expectedOutput: "- namespace: test\n  status: Active\n  current: true\n- namespace: test2\n  status: Sleeping\n  current: false\n",
 		},
 	}
 

--- a/cmd/namespace/list_test.go
+++ b/cmd/namespace/list_test.go
@@ -119,7 +119,7 @@ func Test_displayListNamespaces(t *testing.T) {
 	tests := []struct {
 		name           string
 		format         string
-		input          []types.Namespace
+		input          []namespaceOutput
 		expectedOutput string
 	}{
 		{
@@ -135,29 +135,29 @@ func Test_displayListNamespaces(t *testing.T) {
 		{
 			name:   "default format",
 			format: "",
-			input: []types.Namespace{
-				{ID: "test", Status: "Active"},
-				{ID: "test2", Status: "Sleeping"},
+			input: []namespaceOutput{
+				{Namespace: "test", Status: "Active"},
+				{Namespace: "test2", Status: "Sleeping"},
 			},
-			expectedOutput: "Namespace  Status\ntest *      Active\ntest2        Sleeping\n",
+			expectedOutput: "Namespace  Status\ntest *     Active\ntest2      Sleeping\n",
 		},
 		{
 			name:   "json format",
 			format: "json",
-			input: []types.Namespace{
-				{ID: "test", Status: "Active"},
-				{ID: "test2", Status: "Sleeping"},
+			input: []namespaceOutput{
+				{Namespace: "test", Status: "Active"},
+				{Namespace: "test2", Status: "Sleeping"},
 			},
-			expectedOutput: "[\n {\n  \"id\": \"test\",\n  \"status\": \"Active\",\n  \"sleeping\": false\n },\n {\n  \"id\": \"test2\",\n  \"status\": \"Sleeping\",\n  \"sleeping\": false\n }\n]\n",
+			expectedOutput: "[\n {\n  \"namespace\": \"test\",\n  \"status\": \"Active\"\n },\n {\n  \"namespace\": \"test2\",\n  \"status\": \"Sleeping\"\n }\n]\n",
 		},
 		{
 			name:   "yaml format",
 			format: "yaml",
-			input: []types.Namespace{
-				{ID: "test", Status: "Active"},
-				{ID: "test2", Status: "Sleeping"},
+			input: []namespaceOutput{
+				{Namespace: "test", Status: "Active"},
+				{Namespace: "test2", Status: "Sleeping"},
 			},
-			expectedOutput: "- id: test\n  status: Active\n  sleeping: false\n- id: test2\n  status: Sleeping\n  sleeping: false\n\n",
+			expectedOutput: "- namespace: test\n  status: Active\n- namespace: test2\n  status: Sleeping\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- support `--output` flag for `okteto namespace list`
- implement JSON and YAML output modes
- add unit tests for new functions

## Testing
- `make test` *(fails: cannot download modules)*