### PR TITLE
Fix kubetoken output to include kind

### DIFF
--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -53,6 +54,12 @@ type oktetoCtxCmdRunner interface {
 type Serializer struct{}
 
 func (*Serializer) ToJson(kubetoken types.KubeTokenResponse) (string, error) {
+	if kubetoken.Kind == "" {
+		kubetoken.Kind = "ExecCredential"
+	}
+	if kubetoken.APIVersion == "" {
+		kubetoken.APIVersion = clientauthenticationv1.SchemeGroupVersion.String()
+	}
 	bytes, err := json.MarshalIndent(kubetoken, "", "  ")
 	if err != nil {
 		return "", err

--- a/cmd/kubetoken/serializer_test.go
+++ b/cmd/kubetoken/serializer_test.go
@@ -1,0 +1,29 @@
+package kubetoken
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+func TestSerializerAddsKind(t *testing.T) {
+	serializer := &Serializer{}
+	resp := types.KubeTokenResponse{
+		TokenRequest: authenticationv1.TokenRequest{
+			Status: authenticationv1.TokenRequestStatus{
+				Token: "token",
+			},
+		},
+	}
+
+	out, err := serializer.ToJson(resp)
+	assert.NoError(t, err)
+
+	var data map[string]interface{}
+	err = json.Unmarshal([]byte(out), &data)
+	assert.NoError(t, err)
+	assert.Equal(t, "ExecCredential", data["kind"])
+}


### PR DESCRIPTION
## Summary
- ensure kubetoken serializer sets `kind` and `apiVersion`
- add test for serializer

## Testing
- `go test ./...` *(fails: Test_translateService etc.)*